### PR TITLE
fix: Actually query all provided dateranges, not just the first

### DIFF
--- a/octokit.go
+++ b/octokit.go
@@ -19,21 +19,20 @@ type Octokit struct {
 	client *api.RESTClient
 }
 
-func (self *Octokit) getUsageItemsForDates(enterprise string, dateRanges []APIDate) ([]UsageItem, error) {
+func (octokit *Octokit) getUsageItemsForDates(enterprise string, dateRanges []APIDate) ([]UsageItem, error) {
 	var usageItems []UsageItem
 
 	for _, dateRange := range dateRanges {
 		url := fmt.Sprintf("enterprises/%s/settings/billing/usage?year=%d&month=%d", enterprise, dateRange.Year, dateRange.Month)
 
 		parsedResponse := EnterpriseBillingResponse{}
-		err := self.client.Get(url, &parsedResponse)
+		err := octokit.client.Get(url, &parsedResponse)
 
 		if err != nil {
 			return nil, err
 		}
 
-		// Don't forget to close the response body
-		return parsedResponse.UsageItems, nil
+		usageItems = append(usageItems, parsedResponse.UsageItems...)
 	}
 
 	return usageItems, nil


### PR DESCRIPTION
Fixes Octokit to not early return the first result, but actually loop through all provided date-ranges in order to get all required data for a report that spans multiple months.